### PR TITLE
[codex] add configurable algorithm log level

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primuslabs/zktls-core-sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Primus Labs <dev@primuslabs.org>",
   "description": "Primus zkTLS core sdk",
   "repository": {

--- a/src/algorithm/AlgorithmRunner.ts
+++ b/src/algorithm/AlgorithmRunner.ts
@@ -1,7 +1,8 @@
-import type { AlgorithmBackend } from '../primus_zk';
+import type { AlgorithmBackend, AlgorithmLogLevel } from '../primus_zk';
 
 export type AlgorithmRunnerInitOptions = {
   backend: AlgorithmBackend;
+  logLevel: AlgorithmLogLevel;
 };
 
 export type RunAttestationOptions = {
@@ -29,6 +30,7 @@ export type ParentToChildMessage =
       id: string;
       type: 'init';
       backend: AlgorithmBackend;
+      logLevel: AlgorithmLogLevel;
     }
   | {
       id: string;

--- a/src/algorithm/LocalAlgorithmRunner.ts
+++ b/src/algorithm/LocalAlgorithmRunner.ts
@@ -3,7 +3,7 @@ import type { AlgorithmRunner, AlgorithmRunnerInitOptions, RunAttestationOptions
 
 export class LocalAlgorithmRunner implements AlgorithmRunner {
   init(options: AlgorithmRunnerInitOptions): Promise<string | boolean> {
-    return init(options.backend);
+    return init(options.backend, options.logLevel);
   }
 
   async runAttestation(attParams: unknown, options: RunAttestationOptions): Promise<unknown> {

--- a/src/algorithm/ProcessAlgorithmPool.ts
+++ b/src/algorithm/ProcessAlgorithmPool.ts
@@ -1,7 +1,7 @@
 import { fork } from 'child_process';
 import fs from 'fs';
 import path from 'path';
-import type { AlgorithmBackend } from '../primus_zk';
+import type { AlgorithmBackend, AlgorithmLogLevel } from '../primus_zk';
 import {
   deserializeError,
   type AlgorithmRunner,
@@ -30,6 +30,7 @@ type PoolWorker = {
 type ProcessAlgorithmPoolOptions = {
   backend: AlgorithmBackend;
   concurrency: number;
+  logLevel: AlgorithmLogLevel;
   workerPath?: string;
   createWorker?: () => WorkerProcess;
 };
@@ -37,6 +38,7 @@ type ProcessAlgorithmPoolOptions = {
 export class ProcessAlgorithmPool implements AlgorithmRunner {
   private readonly backend: AlgorithmBackend;
   private readonly concurrency: number;
+  private readonly logLevel: AlgorithmLogLevel;
   private readonly workerPath: string;
   private readonly createWorker?: () => WorkerProcess;
   private readonly workers: PoolWorker[] = [];
@@ -47,6 +49,7 @@ export class ProcessAlgorithmPool implements AlgorithmRunner {
   constructor(options: ProcessAlgorithmPoolOptions) {
     this.backend = options.backend;
     this.concurrency = Math.max(2, Math.floor(options.concurrency));
+    this.logLevel = options.logLevel;
     this.workerPath = options.workerPath || resolveDefaultWorkerPath();
     this.createWorker = options.createWorker;
   }
@@ -133,6 +136,7 @@ export class ProcessAlgorithmPool implements AlgorithmRunner {
         id,
         type: 'init',
         backend: this.backend,
+        logLevel: this.logLevel,
       });
     });
   }

--- a/src/algorithm/process_worker.ts
+++ b/src/algorithm/process_worker.ts
@@ -13,7 +13,7 @@ process.on('message', async (message: ParentToChildMessage) => {
   try {
     if (message.type === 'init') {
       runner = new LocalAlgorithmRunner();
-      const result = await runner.init({ backend: message.backend });
+      const result = await runner.init({ backend: message.backend, logLevel: message.logLevel });
       send({ id: message.id, type: 'ready', result });
       return;
     }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -65,6 +65,7 @@ export type StartAttestationInput = import('./classes/AttRequest').AttRequest | 
 export type PrimusInitOptions = {
     backend?: import('./primus_zk').AlgorithmBackend;
     concurrency?: number;
+    logLevel?: import('./primus_zk').AlgorithmLogLevel;
 }
 
 export type AttestationProgressEvent =

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,12 @@ import {
 import { AttRequest } from './classes/AttRequest'
 import { AlgorithmUrls } from "./classes/AlgorithmUrls";
 import { encodeAttestation } from "./utils";
-import { init, getAttestation, getAttestationResult, AlgorithmBackend } from "./primus_zk";
+import {
+  init,
+  getAttestation,
+  getAttestationResult,
+  AlgorithmBackend,
+} from "./primus_zk";
 import { ProcessAlgorithmPool } from './algorithm/ProcessAlgorithmPool';
 import { assemblyParams } from './assembly_params';
 import { ZkAttestationError } from './classes/Error'
@@ -78,10 +83,11 @@ class PrimusCoreTLS {
       this._algorithmPool = new ProcessAlgorithmPool({
         backend: initOptions.backend,
         concurrency: this._concurrency,
+        logLevel: initOptions.logLevel,
       });
-      return this._algorithmPool.init({ backend: initOptions.backend });
+      return this._algorithmPool.init({ backend: initOptions.backend, logLevel: initOptions.logLevel });
     }
-    return await init(initOptions.backend);
+    return await init(initOptions.backend, initOptions.logLevel);
   }
 
   async close(): Promise<void> {
@@ -96,12 +102,14 @@ class PrimusCoreTLS {
       return {
         backend: modeOrOptions,
         concurrency: 1,
+        logLevel: 'error',
       };
     }
     const concurrency = modeOrOptions.concurrency ?? 1;
     return {
       backend: modeOrOptions.backend ?? 'auto',
       concurrency: Number.isFinite(concurrency) && concurrency > 1 ? Math.floor(concurrency) : 1,
+      logLevel: modeOrOptions.logLevel ?? 'error',
     };
   }
 
@@ -762,3 +770,4 @@ export type {
   StartAttestationInput,
   StartAttestationOptions,
 } from './index.d';
+export type { AlgorithmBackend, AlgorithmLogLevel } from './primus_zk';

--- a/src/primus_zk.ts
+++ b/src/primus_zk.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 global.WebSocket = require('ws');
 export type AlgorithmBackend = 'auto' | 'native' | 'wasm';
+export type AlgorithmLogLevel = 'debug' | 'info' | 'perf' | 'error';
 export type GetAttestationResultOptions = {
   timeout?: number;
   pollIntervalMs?: number;
@@ -79,10 +80,10 @@ async function initAlgorithm(mode: AlgorithmBackend = 'auto'): Promise<(params: 
 }
 
 let callAlgorithm = null;
-export const init = async (mode: AlgorithmBackend = 'auto') => {
+export const init = async (mode: AlgorithmBackend = 'auto', logLevel: AlgorithmLogLevel = 'error') => {
   callAlgorithm = await initAlgorithm(mode);
 
-  const logParams = buildAlgorithmParams('setLogLevel', { logLevel: 'error' });
+  const logParams = buildAlgorithmParams('setLogLevel', { logLevel });
   const logResult = await callAlgorithm(logParams);
 
   const params = buildAlgorithmParams('init', {});

--- a/test/initConcurrency.test.ts
+++ b/test/initConcurrency.test.ts
@@ -33,8 +33,16 @@ describe('init concurrency options', () => {
 
     await client.init('app-id', undefined, 'wasm');
 
-    expect(init).toHaveBeenCalledWith('wasm');
+    expect(init).toHaveBeenCalledWith('wasm', 'error');
     expect(ProcessAlgorithmPool).not.toHaveBeenCalled();
+  });
+
+  it('passes a configured log level to the local algorithm', async () => {
+    const client = new PrimusCoreTLS();
+
+    await client.init('app-id', undefined, { backend: 'wasm', logLevel: 'perf' });
+
+    expect(init).toHaveBeenCalledWith('wasm', 'perf');
   });
 
   it('creates a lazy process pool without initializing the local algorithm when concurrency is greater than 1', async () => {
@@ -46,6 +54,7 @@ describe('init concurrency options', () => {
     expect(ProcessAlgorithmPool).toHaveBeenCalledWith({
       backend: 'native',
       concurrency: 3,
+      logLevel: 'error',
     });
   });
 });

--- a/test/primusZkLogLevel.test.ts
+++ b/test/primusZkLogLevel.test.ts
@@ -1,0 +1,31 @@
+const callAlgorithm = jest.fn().mockResolvedValue('{"retcode":"0"}');
+
+jest.mock('../src/algorithm/client_plugin.js', () => {
+  const module: Record<string, unknown> = {
+    cwrap: jest.fn(() => callAlgorithm),
+  };
+  Object.defineProperty(module, 'onRuntimeInitialized', {
+    set(callback: () => void) {
+      setImmediate(callback);
+    },
+  });
+  return module;
+});
+
+import { init } from '../src/primus_zk';
+
+describe('primus_zk log level', () => {
+  beforeEach(() => {
+    callAlgorithm.mockClear();
+  });
+
+  it('sets the configured log level before initializing the algorithm', async () => {
+    await (init as (backend: 'wasm', logLevel: string) => Promise<string>)('wasm', 'debug');
+
+    expect(JSON.parse(callAlgorithm.mock.calls[0][0])).toMatchObject({
+      method: 'setLogLevel',
+      params: { logLevel: 'debug' },
+    });
+    expect(JSON.parse(callAlgorithm.mock.calls[1][0])).toMatchObject({ method: 'init' });
+  });
+});

--- a/test/processAlgorithmPool.test.ts
+++ b/test/processAlgorithmPool.test.ts
@@ -27,6 +27,7 @@ describe('ProcessAlgorithmPool', () => {
     const pool = new ProcessAlgorithmPool({
       backend: 'native',
       concurrency: 2,
+      logLevel: 'error',
       createWorker: () => {
         const worker = new FakeWorker();
         workers.push(worker);
@@ -69,11 +70,44 @@ describe('ProcessAlgorithmPool', () => {
     await pool.close();
   });
 
+  it('passes the configured log level when initializing a worker', async () => {
+    const workers: FakeWorker[] = [];
+    const pool = new ProcessAlgorithmPool({
+      backend: 'native',
+      concurrency: 2,
+      logLevel: 'info',
+      createWorker: () => {
+        const worker = new FakeWorker();
+        workers.push(worker);
+        return worker;
+      },
+    } as ConstructorParameters<typeof ProcessAlgorithmPool>[0]);
+
+    const task = pool.runAttestation({ requestid: 'first' }, { timeout: 1000, pollIntervalMs: 10 });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(workers[0].sent[0]).toEqual(
+      expect.objectContaining({
+        type: 'init',
+        backend: 'native',
+        logLevel: 'info',
+      })
+    );
+
+    const attest = workers[0].sent.find((message) => (message as { type: string }).type === 'attest') as {
+      id: string;
+    };
+    workers[0].emit('message', { id: attest.id, type: 'done', result: { retcode: '0' } });
+    await task;
+    await pool.close();
+  });
+
   it('reuses an idle worker instead of starting another one', async () => {
     const workers: FakeWorker[] = [];
     const pool = new ProcessAlgorithmPool({
       backend: 'native',
       concurrency: 3,
+      logLevel: 'error',
       createWorker: () => {
         const worker = new FakeWorker();
         workers.push(worker);


### PR DESCRIPTION
## What changed

- expose `logLevel` in `PrimusInitOptions`
- support `debug`, `info`, `perf`, and `error`, preserving `error` as the default
- propagate the configured level through local and concurrent worker initialization
- bump the package version to `0.3.2`

## Developer impact

Existing initialization calls remain compatible. Developers can optionally configure the algorithm log level when initializing the SDK.

## Validation

- `npm test -- --runInBand test/initConcurrency.test.ts test/processAlgorithmPool.test.ts test/primusZkLogLevel.test.ts`
- `npm run build:test`

The repository-wide test command also runs live external integration tests; those encountered service connection failures, rate limiting, and a native worker `SIGSEGV` during local verification.
